### PR TITLE
fix: prevent preview flicker when toggling Preview/Code tabs

### DIFF
--- a/src/app/__tests__/main-content.test.tsx
+++ b/src/app/__tests__/main-content.test.tsx
@@ -1,0 +1,149 @@
+import { test, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MainContent } from "@/app/main-content";
+
+vi.mock("@/lib/contexts/file-system-context", () => ({
+  FileSystemProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useFileSystem: vi.fn(),
+}));
+
+vi.mock("@/lib/contexts/chat-context", () => ({
+  ChatProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useChat: vi.fn(),
+}));
+
+vi.mock("@/components/chat/ChatInterface", () => ({
+  ChatInterface: () => <div data-testid="chat-interface">ChatInterface</div>,
+}));
+
+vi.mock("@/components/editor/FileTree", () => ({
+  FileTree: () => <div data-testid="file-tree">FileTree</div>,
+}));
+
+vi.mock("@/components/editor/CodeEditor", () => ({
+  CodeEditor: () => <div data-testid="code-editor">CodeEditor</div>,
+}));
+
+vi.mock("@/components/preview/PreviewFrame", () => ({
+  PreviewFrame: () => <div data-testid="preview-frame">PreviewFrame</div>,
+}));
+
+vi.mock("@/components/HeaderActions", () => ({
+  HeaderActions: () => <div data-testid="header-actions">HeaderActions</div>,
+}));
+
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <div className={className}>{children}</div>,
+  ResizablePanel: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <div className={className}>{children}</div>,
+  ResizableHandle: () => <div />,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+test("renders Preview tab as active by default", () => {
+  render(<MainContent />);
+
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+
+  expect(previewTab.getAttribute("data-state")).toBe("active");
+  expect(codeTab.getAttribute("data-state")).toBe("inactive");
+});
+
+test("shows PreviewFrame when Preview tab is active", () => {
+  render(<MainContent />);
+
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+  expect(screen.queryByTestId("file-tree")).toBeNull();
+});
+
+test("switches to Code view when Code tab is clicked", async () => {
+  const user = userEvent.setup();
+  render(<MainContent />);
+
+  await user.click(screen.getByRole("tab", { name: "Code" }));
+
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+  expect(screen.getByTestId("code-editor")).toBeDefined();
+  expect(screen.getByTestId("file-tree")).toBeDefined();
+});
+
+test("switches back to Preview view when Preview tab is clicked after Code", async () => {
+  const user = userEvent.setup();
+  render(<MainContent />);
+
+  await user.click(screen.getByRole("tab", { name: "Code" }));
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+
+  await user.click(screen.getByRole("tab", { name: "Preview" }));
+
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+  expect(screen.queryByTestId("file-tree")).toBeNull();
+});
+
+test("Code tab becomes active after clicking it", async () => {
+  const user = userEvent.setup();
+  render(<MainContent />);
+
+  await user.click(screen.getByRole("tab", { name: "Code" }));
+
+  expect(screen.getByRole("tab", { name: "Code" }).getAttribute("data-state")).toBe("active");
+  expect(screen.getByRole("tab", { name: "Preview" }).getAttribute("data-state")).toBe("inactive");
+});
+
+test("Preview tab becomes active again after toggling back", async () => {
+  const user = userEvent.setup();
+  render(<MainContent />);
+
+  await user.click(screen.getByRole("tab", { name: "Code" }));
+  await user.click(screen.getByRole("tab", { name: "Preview" }));
+
+  expect(screen.getByRole("tab", { name: "Preview" }).getAttribute("data-state")).toBe("active");
+});
+
+test("multiple toggles work correctly", async () => {
+  const user = userEvent.setup();
+  render(<MainContent />);
+
+  for (let i = 0; i < 3; i++) {
+    await user.click(screen.getByRole("tab", { name: "Code" }));
+    expect(screen.queryByTestId("preview-frame")).toBeNull();
+    expect(screen.getByTestId("code-editor")).toBeDefined();
+
+    await user.click(screen.getByRole("tab", { name: "Preview" }));
+    expect(screen.getByTestId("preview-frame")).toBeDefined();
+    expect(screen.queryByTestId("code-editor")).toBeNull();
+  }
+});
+
+test("renders chat interface regardless of active tab", async () => {
+  const user = userEvent.setup();
+  render(<MainContent />);
+
+  expect(screen.getByTestId("chat-interface")).toBeDefined();
+
+  await user.click(screen.getByRole("tab", { name: "Code" }));
+  expect(screen.getByTestId("chat-interface")).toBeDefined();
+});

--- a/src/components/preview/PreviewFrame.tsx
+++ b/src/components/preview/PreviewFrame.tsx
@@ -13,17 +13,12 @@ export function PreviewFrame() {
   const { getAllFiles, refreshTrigger } = useFileSystem();
   const [error, setError] = useState<string | null>(null);
   const [entryPoint, setEntryPoint] = useState<string>("/App.jsx");
-  const [isFirstLoad, setIsFirstLoad] = useState(true);
+  const isFirstLoad = useRef(true);
 
   useEffect(() => {
     const updatePreview = () => {
       try {
         const files = getAllFiles();
-
-        // Clear error first when we have files
-        if (files.size > 0 && error) {
-          setError(null);
-        }
 
         // Find the entry point - look for App.jsx, App.tsx, index.jsx, or index.tsx
         let foundEntryPoint = entryPoint;
@@ -54,7 +49,7 @@ export function PreviewFrame() {
         }
 
         if (files.size === 0) {
-          if (isFirstLoad) {
+          if (isFirstLoad.current) {
             setError("firstLoad");
           } else {
             setError("No files to preview");
@@ -62,10 +57,7 @@ export function PreviewFrame() {
           return;
         }
 
-        // We have files, so it's no longer the first load
-        if (isFirstLoad) {
-          setIsFirstLoad(false);
-        }
+        isFirstLoad.current = false;
 
         if (!foundEntryPoint || !files.has(foundEntryPoint)) {
           setError(
@@ -96,7 +88,7 @@ export function PreviewFrame() {
     };
 
     updatePreview();
-  }, [refreshTrigger, getAllFiles, entryPoint, error, isFirstLoad]);
+  }, [refreshTrigger, getAllFiles, entryPoint]);
 
   if (error) {
     if (error === "firstLoad") {

--- a/src/components/preview/__tests__/PreviewFrame.test.tsx
+++ b/src/components/preview/__tests__/PreviewFrame.test.tsx
@@ -1,0 +1,134 @@
+import { test, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { PreviewFrame } from "@/components/preview/PreviewFrame";
+import { useFileSystem } from "@/lib/contexts/file-system-context";
+import * as jsxTransformer from "@/lib/transform/jsx-transformer";
+
+vi.mock("@/lib/contexts/file-system-context");
+
+vi.mock("@/lib/transform/jsx-transformer", () => ({
+  createImportMap: vi.fn(() => ({ importMap: {}, styles: "", errors: [] })),
+  createPreviewHTML: vi.fn(() => "<html><body>preview</body></html>"),
+}));
+
+vi.mock("lucide-react", () => ({
+  AlertCircle: () => <div>AlertCircle</div>,
+}));
+
+const mockUseFileSystem = useFileSystem as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  mockUseFileSystem.mockReturnValue({
+    getAllFiles: vi.fn(() => new Map()),
+    refreshTrigger: 0,
+  });
+});
+
+test("shows welcome screen on first load with no files", () => {
+  render(<PreviewFrame />);
+
+  expect(screen.getByText("Welcome to UI Generator")).toBeDefined();
+});
+
+test("shows iframe when files are present", () => {
+  mockUseFileSystem.mockReturnValue({
+    getAllFiles: vi.fn(
+      () =>
+        new Map([["/App.jsx", "export default function App() { return <div /> }"]])
+    ),
+    refreshTrigger: 0,
+  });
+
+  render(<PreviewFrame />);
+
+  const iframe = document.querySelector("iframe");
+  expect(iframe).toBeTruthy();
+});
+
+test("shows error when no JSX entry point found", () => {
+  mockUseFileSystem.mockReturnValue({
+    getAllFiles: vi.fn(() => new Map([["/styles.css", "body { color: red; }"]])),
+    refreshTrigger: 0,
+  });
+
+  render(<PreviewFrame />);
+
+  expect(
+    screen.getByText(
+      "No React component found. Create an App.jsx or index.jsx file to get started."
+    )
+  ).toBeDefined();
+});
+
+test("does not show welcome screen after first load when files are removed", () => {
+  mockUseFileSystem.mockReturnValue({
+    getAllFiles: vi.fn(
+      () =>
+        new Map([["/App.jsx", "export default function App() { return <div /> }"]])
+    ),
+    refreshTrigger: 0,
+  });
+
+  const { rerender } = render(<PreviewFrame />);
+
+  // Now remove files — after having seen files, it should show "No files to preview" not the welcome screen
+  mockUseFileSystem.mockReturnValue({
+    getAllFiles: vi.fn(() => new Map()),
+    refreshTrigger: 1,
+  });
+
+  rerender(<PreviewFrame />);
+
+  expect(screen.queryByText("Welcome to UI Generator")).toBeNull();
+  expect(screen.getByText("No files to preview")).toBeDefined();
+});
+
+test("createPreviewHTML is called only once on initial render with files", () => {
+  const createPreviewHTMLMock = vi.spyOn(jsxTransformer, "createPreviewHTML");
+
+  mockUseFileSystem.mockReturnValue({
+    getAllFiles: vi.fn(
+      () =>
+        new Map([["/App.jsx", "export default function App() { return <div /> }"]])
+    ),
+    refreshTrigger: 0,
+  });
+
+  render(<PreviewFrame />);
+
+  expect(createPreviewHTMLMock).toHaveBeenCalledTimes(1);
+});
+
+test("preview updates when refreshTrigger changes", () => {
+  const createPreviewHTMLMock = vi.spyOn(jsxTransformer, "createPreviewHTML");
+
+  mockUseFileSystem.mockReturnValue({
+    getAllFiles: vi.fn(
+      () =>
+        new Map([["/App.jsx", "export default function App() { return <div /> }"]])
+    ),
+    refreshTrigger: 0,
+  });
+
+  const { rerender } = render(<PreviewFrame />);
+  const callsAfterFirstRender = createPreviewHTMLMock.mock.calls.length;
+
+  mockUseFileSystem.mockReturnValue({
+    getAllFiles: vi.fn(
+      () =>
+        new Map([["/App.jsx", "export default function App() { return <span /> }"]])
+    ),
+    refreshTrigger: 1,
+  });
+
+  rerender(<PreviewFrame />);
+
+  expect(createPreviewHTMLMock.mock.calls.length).toBeGreaterThan(
+    callsAfterFirstRender
+  );
+});


### PR DESCRIPTION
Fixes #8

## Changes

- Convert `isFirstLoad` from `useState` to `useRef` in `PreviewFrame` to prevent extra effect runs
- Remove `error` and `isFirstLoad` from `useEffect` dependency array
- Add 8 toggle button tests in `main-content.test.tsx`
- Add 6 PreviewFrame tests in `PreviewFrame.test.tsx`

Generated with [Claude Code](https://claude.ai/code)